### PR TITLE
fix chrome instances keep open

### DIFF
--- a/index.js
+++ b/index.js
@@ -903,15 +903,17 @@ const sleepingTime = sleepingTimeInMinutes * 60000;
                 })
 
                 await page.waitForTimeout(5000);
-                await page.evaluate(async function () {
-                    await SM.Logout();
-                        }).catch(async function(){ 
+		await browsers[0].close();
+                browsers = [];
+                //await page.evaluate(async function () {
+                    //await SM.Logout();
+                        //}).catch(async function(){ 
                             //const pages =  browsers[0].pages();
                             //await Promise.all(pages.map(page =>page.close()));
-                            await browsers[0].close();
-                            browsers = [];
+                            //await browsers[0].close();
+                            //browsers = [];
                             //await browsers[0].process().kill('SIGKILL'); 
-                        })
+                        //})
             }
             let endTimer = new Date().getTime();
 			let totalTime = endTimer - startTimer;


### PR DESCRIPTION
Even after the fix, come schrome instances are opening in parallel, this fix it, instead of logging out and reusing the same chrome instance, it will close the browser and reopen o each account. impact on time perfomance is minimal (some seconds at max)